### PR TITLE
[fix] Vite 환경에서 Axios 인스턴스 환경 변수 적용 오류 수정 (#1)

### DIFF
--- a/src/services/axios.js
+++ b/src/services/axios.js
@@ -1,7 +1,9 @@
 import axios from 'axios';
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
 export const api = axios.create({
-  baseURL: process.env.REACT_APP_API_BASE_URL,
+  baseURL: API_BASE_URL,
   headers: {
     'Content-Type': 'application/json',
   },
@@ -14,3 +16,5 @@ api.interceptors.request.use((config) => {
   }
   return config;
 });
+
+export default api;

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  define: {
+    "process.env": {},
+  },
+});
+


### PR DESCRIPTION
## 📌 개요
- Vite 환경에서 `process.env`를 사용할 수 없으므로, Axios 인스턴스에서 환경 변수 처리를 `import.meta.env`로 변경
- Vite의 `process is not defined` 오류를 해결하기 위해 `vite.config.js`에서 `process.env`를 정의

## 🗒️ 작업 내용 요약
- `axios.js`에서 `process.env` → `import.meta.env`로 변경
- `export default api` 추가하여 import 방식 개선
- `vite.config.js`에 `process.env` 정의 추가

## 🔗 관련 이슈
- Closes #1