### PR TITLE
[feat] 기본 레이아웃 설정 (#4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.7.9",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-icons": "^5.4.0",
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.1.5"
       },
@@ -5123,6 +5124,15 @@
       },
       "peerDependencies": {
         "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.4.0.tgz",
+      "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.7.9",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-icons": "^5.4.0",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.1.5"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,20 +1,43 @@
 import './App.css';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  useLocation,
+} from 'react-router-dom';
 import SignUpPage from './pages/SignUpPage';
 import LoginPage from './pages/LoginPage';
+import NavBar from './components/NavBar';
+
+const AppContent = () => {
+  const location = useLocation();
+  const isHomePage = location.pathname === '/';
+
+  return (
+    <div className="min-h-screen bg-gray-200">
+      {!isHomePage && (
+        <div className="fixed top-0 left-0 z-50 w-full">
+          <div className="max-w-3xl mx-auto ">
+            <NavBar />
+          </div>
+        </div>
+      )}
+      <div className={'max-w-3xl mx-auto'}>
+        <Routes>
+          <Route path="/" />
+          <Route path="/signup" element={<SignUpPage />} />
+          <Route path="/login" element={<LoginPage />} />
+        </Routes>
+      </div>
+    </div>
+  );
+};
 
 const App = () => {
   return (
-    <div className="min-h-screen bg-gray-200">
-      <div className="max-w-3xl min-h-screen mx-auto">
-        <Router>
-          <Routes>
-            <Route path="/signup" element={<SignUpPage />} />
-            <Route path="/login" element={<LoginPage />} />
-          </Routes>
-        </Router>
-      </div>
-    </div>
+    <Router>
+      <AppContent />
+    </Router>
   );
 };
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,12 +5,16 @@ import LoginPage from './pages/LoginPage';
 
 const App = () => {
   return (
-    <Router>
-      <Routes>
-        <Route path="/signup" element={<SignUpPage />} />
-        <Route path="/login" element={<LoginPage />} />
-      </Routes>
-    </Router>
+    <div className="min-h-screen bg-gray-200">
+      <div className="max-w-3xl min-h-screen mx-auto">
+        <Router>
+          <Routes>
+            <Route path="/signup" element={<SignUpPage />} />
+            <Route path="/login" element={<LoginPage />} />
+          </Routes>
+        </Router>
+      </div>
+    </div>
   );
 };
 

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { FaArrowLeft, FaHome } from 'react-icons/fa';
+
+const NavBar = () => {
+  const navigate = useNavigate();
+
+  const goBack = () => {
+    navigate(-1);
+  };
+
+  const goHome = () => {
+    navigate('/');
+  };
+
+  // TODO: 상단바 추후 디자인 보고 수정 필요
+  return (
+    <nav style={styles.nav}>
+      <button onClick={goBack} style={styles.button}>
+        <FaArrowLeft />
+      </button>
+      <span style={styles.text}>텍스트</span>
+      <button onClick={goHome} style={styles.button}>
+        <FaHome />
+      </button>
+    </nav>
+  );
+};
+
+const styles = {
+  nav: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '10px',
+    backgroundColor: '#f8f9fa',
+    borderBottom: '1px solid #dee2e6',
+  },
+  button: {
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: '20px',
+  },
+  text: {
+    fontSize: '18px',
+    fontWeight: 'bold',
+  },
+};
+
+export default NavBar;


### PR DESCRIPTION
## 📌 개요
- 레이아웃 설정

## 🗒️ 작업 내용 요약
- App.jsx에서 max width 설정
- 공통 네비게이션 바 추가
    - 뒤로가기(왼쪽), 홈화면 이동(오른쪽)으로 구현
    - 오른쪽 유틸은 페이지마다 변경되고 있습니다. 추후에 기획 및 디자인 확정되면 수정해야합니다.
    - 가운데 텍스트도 추후 수정 필요합니다.

## 🔗 관련 이슈
- Closes #4 